### PR TITLE
Add client side handling for too long inputs

### DIFF
--- a/src/semel.cr
+++ b/src/semel.cr
@@ -34,7 +34,6 @@ end
 
 # Landing page for Alice with the form to create a secret.
 get "/" do
-  max_ciphertext_length = MAX_CIPHERTEXT_LENGTH
   render "src/views/new.ecr", "src/views/layout.ecr"
 end
 

--- a/src/semel.cr
+++ b/src/semel.cr
@@ -34,6 +34,7 @@ end
 
 # Landing page for Alice with the form to create a secret.
 get "/" do
+  max_ciphertext_length = MAX_CIPHERTEXT_LENGTH
   render "src/views/new.ecr", "src/views/layout.ecr"
 end
 

--- a/src/views/layout.ecr
+++ b/src/views/layout.ecr
@@ -119,6 +119,7 @@
       cursor: pointer;
       height: 51px;
     }
+
     #sharable-container button {
       background: #F0F0F0;
       border: 1px solid rgba(0, 0, 0, 0.2);
@@ -132,6 +133,16 @@
       margin: 5px 0;
       font-family: monospace;
     }
+
+    #error-container {
+      margin-top: 50px;
+      padding: 12px;
+      background: rgba(255, 0, 0, 0.3);
+      border-radius: 10px;
+      font-size: 18px;
+      color: rgb(120, 0, 0);
+    }
+
     #explanation {
       margin: var(--explanation-margin);
     }
@@ -174,19 +185,6 @@
       top: 13px;
       pointer-events: none;
       transform: scaleY(0.8);
-    }
-
-    #error-container {
-      margin-top: 50px;
-      padding: 12px;
-      background: rgba(255, 0, 0, 0.3);
-      border-radius: 10px;
-    }
-
-    #error {
-      margin: 0;
-      font-size: 18px;
-      color: rgb(120, 0, 0);
     }
   </style>
 </head>

--- a/src/views/layout.ecr
+++ b/src/views/layout.ecr
@@ -175,6 +175,19 @@
       pointer-events: none;
       transform: scaleY(0.8);
     }
+
+    #error-container {
+      margin-top: 50px;
+      padding: 12px;
+      background: rgba(255, 0, 0, 0.3);
+      border-radius: 10px;
+    }
+
+    #error {
+      margin: 0;
+      font-size: 18px;
+      color: rgb(120, 0, 0);
+    }
   </style>
 </head>
 <script id="script-global">

--- a/src/views/new.ecr
+++ b/src/views/new.ecr
@@ -136,7 +136,7 @@
   </section>
 
   <section id="error-container" style="display: none">
-  <p id="error"></p>
+    <span id="error"></span>
   </section>
 
   <section id="explanation">

--- a/src/views/new.ecr
+++ b/src/views/new.ecr
@@ -11,15 +11,15 @@
 
       async function encryptAndStore() {
         const { key, ciphertext } = await encryptLocally(plaintext());
-        const isInputTooLong = to_base64(ciphertext).length > <%= max_ciphertext_length %>;
-        if (isInputTooLong) {
-          displayError('Your input is too long!');
-          hideSharable();
-          return;
+        const { url, errors } = await storeRemotely(ciphertext, expiresInSeconds());
+
+        if(url) {
+          showSharable(`${url}:${to_base64(key)}`);
         }
-        hideError();
-        const { url } = await storeRemotely(ciphertext, expiresInSeconds());
-        showSharable(`${url}:${to_base64(key)}`);
+
+        if(errors) {
+          showError(errors.map((e) => e.detail).join(", "));
+        }
       }
 
       async function encryptLocally(plaintext) {
@@ -75,15 +75,15 @@
         document.getElementById('sharable-container').style.removeProperty('display');
       }
       function hideSharable() {
-
         document.getElementById('sharable').innerText = '';
         document.getElementById('sharable-container').style.display = 'none';
       }
-      function displayError(error) {
-        document.getElementById('error').innerHTML = error;
+      function showError(error) {
+        document.getElementById('error').innerText = error;
         document.getElementById('error-container').style.removeProperty('display');
       }
       function hideError() {
+        document.getElementById('error').innerText = '';
         document.getElementById('error-container').style.display = 'none';
       }
       function copyUrlToClipboard(copier) {
@@ -99,7 +99,7 @@
     </script>
 
     <label for="plaintext">Secret to share</label>
-    <textarea id="plaintext" placeholder="My secret…" rows="5"></textarea>
+    <textarea id="plaintext" placeholder="My secret…" rows="5" onchange="hideSharable(); hideError()"></textarea>
 
     <div style="display: flex; align-items: flex-end; column-gap: 20px">
       <div style="flex-basis: 0; flex-grow: 1">

--- a/src/views/new.ecr
+++ b/src/views/new.ecr
@@ -11,6 +11,13 @@
 
       async function encryptAndStore() {
         const { key, ciphertext } = await encryptLocally(plaintext());
+        const isInputTooLong = to_base64(ciphertext).length > <%= max_ciphertext_length %>;
+        if (isInputTooLong) {
+          displayError('Your input is too long!');
+          hideSharable();
+          return;
+        }
+        hideError();
         const { url } = await storeRemotely(ciphertext, expiresInSeconds());
         showSharable(`${url}:${to_base64(key)}`);
       }
@@ -67,6 +74,18 @@
         document.getElementById('sharable').innerText = url;
         document.getElementById('sharable-container').style.removeProperty('display');
       }
+      function hideSharable() {
+
+        document.getElementById('sharable').innerText = '';
+        document.getElementById('sharable-container').style.display = 'none';
+      }
+      function displayError(error) {
+        document.getElementById('error').innerHTML = error;
+        document.getElementById('error-container').style.removeProperty('display');
+      }
+      function hideError() {
+        document.getElementById('error-container').style.display = 'none';
+      }
       function copyUrlToClipboard(copier) {
         const sharable = document.getElementById('sharable')
         sharable.select();
@@ -114,6 +133,10 @@
     </label>
     <textarea id="sharable" disabled></textarea>
     <button onclick="copyUrlToClipboard(this)">Copy URL to clipboard</button>
+  </section>
+
+  <section id="error-container" style="display: none">
+  <p id="error"></p>
   </section>
 
   <section id="explanation">


### PR DESCRIPTION
Now the length of the encrypted inputs gets checked and if it is longer than the (in the backend) set maximum the request doesn't get sent and an error is displayed. Fixes #4 