### PR TITLE
Clarify ciphertext constraints

### DIFF
--- a/src/semel.cr
+++ b/src/semel.cr
@@ -52,7 +52,7 @@ post "/create" do |env|
 
   if ciphertext.size > MAX_CIPHERTEXT_LENGTH
     halt env, status_code: 400, response: (
-      { errors: [{ status: "400", detail: "Maximum #{MAX_CIPHERTEXT_LENGTH} characters allowed." }] }.to_json
+      { errors: [{ status: "400", detail: "Ciphertext uses #{ciphertext.size}/#{MAX_CIPHERTEXT_LENGTH} codepoints. Please reduce plaintext size." }] }.to_json
     )
   end
 

--- a/src/semel.cr
+++ b/src/semel.cr
@@ -4,7 +4,11 @@ require "./storage"
 serve_static false
 
 storage = Storage.new(ENV["KEMAL_ENV"]? || "development")
+
+# Ciphertext expires after this amount of seconds
 MAX_EXPIRES_IN_SECONDS = 60 * 60 * 24 * 30 # 30 days
+
+# Maximum allowed codepoints in ciphertext
 MAX_CIPHERTEXT_LENGTH = 1_401 # Length of first illegal prime number, see https://t5k.org/curios/page.php?number_id=953
 
 before_all do |env|


### PR DESCRIPTION
I found it to be a bit confusing what the ciphertext length actually means, so I added a clarifying comment.
Also, the current error message for a too long ciphertext is a bit misleading, so I changed it.