### PR TITLE
Validate secret ID to prevent path traversal

### DIFF
--- a/src/views/try.ecr
+++ b/src/views/try.ecr
@@ -56,8 +56,9 @@
     <script id="script-dom">
       // Here is the DOM tooling. It doesn't act on its own but should be triggered by inline event handlers.
 
-      function secretIdFromHash()        { return location.hash.substring(1).split(':').filter(x => x)[0]; }
-      function secretKeyFromHash()       { return location.hash.substring(1).split(':').filter(x => x)[1]; }
+      function urlHashPart(i)            { return location.hash.substring(1).split(':').filter(x => x)[i]; }
+      function secretIdFromHash()        { return urlHashPart(0).match(/^[0-9a-f-]+$/)?.[0] || alert('Attention! Your link is invalid.'); }
+      function secretKeyFromHash()       { return urlHashPart(1); }
       function secretKeyFromInput()      { return document.getElementById('secret-key').value; }
       function showPlaintext(plaintext)  {
         document.getElementById('plaintext').value = plaintext;


### PR DESCRIPTION
https://github.com/user-attachments/assets/9241dad4-6e34-4ea0-9e10-ab188c7469a0

If the secret ID contains something else than the letters from a-f, numbers 0-9 or a hyphen, `undefined` will be passed. Also, an alert gets displayed.
This prevents path traversal.